### PR TITLE
Remove some unnecessary continues in the recdir unit

### DIFF
--- a/src/recdir.c
+++ b/src/recdir.c
@@ -78,11 +78,8 @@ struct dirent *recdir_read(RECDIR *recdir)
         struct dirent *ent = readdir(top->dir);
         if (ent) {
             if (ent->d_type == DT_DIR) {
-                if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
-                    continue;
-                } else {
+                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0) {
                     recdir_push(recdir, join_path(top->path, ent->d_name));
-                    continue;
                 }
             } else {
                 return ent;
@@ -90,10 +87,8 @@ struct dirent *recdir_read(RECDIR *recdir)
         } else {
             if (errno) {
                 return NULL;
-            } else {
-                recdir_pop(recdir);
-                continue;
             }
+            recdir_pop(recdir);
         }
     }
 


### PR DESCRIPTION
I was reading the source code and I stumbled across some unnecessary `continue` statements inside the `recdir_read` function.
This PR keeps the flow intact but at the same time eliminates all `continue` statements from it and as a result making it easier for someone to follow the code.